### PR TITLE
Removed autoloading of bootstrap script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
 
     "autoload": {
-        "files": ["bootstrap.php"]
+        
     },
 
     "archive": {


### PR DESCRIPTION
This makes it possible to customize constants in bootstrap, and manually call this file from your script