### PR TITLE
Fixed wrong created date on datastore items

### DIFF
--- a/modules/core/Datastore/bootstrap.php
+++ b/modules/core/Datastore/bootstrap.php
@@ -65,7 +65,7 @@ $this->module("datastore")->extend([
         $data["modified"] = time();
 
         if (!isset($data["_id"])){
-            $data["created"] = $datastore["modified"];
+            $data["created"] = $data["modified"];
         }
 
         return $this->app->db->save("datastore/{$collection}", $data);


### PR DESCRIPTION
Was wondering why the created date on all my datastore items was the same. This fixes it.