### PR TITLE
Same breadcrumb in Datastore config as in other modules

### DIFF
--- a/modules/core/Datastore/views/index.php
+++ b/modules/core/Datastore/views/index.php
@@ -7,7 +7,7 @@
 <div data-ng-controller="datastore" ng-cloak>
 
     <nav class="uk-navbar uk-margin-large-bottom">
-        <span class="uk-hidden-small uk-navbar-brand">@lang('Datastore')</span>
+        <span class="uk-hidden-small uk-navbar-brand"><a href="@route('/settingspage')">@lang('Settings')</a> / @lang('Datastore')</span>
         <div class="uk-hidden-small uk-navbar-content" data-ng-show="tables && tables.length">
             <form class="uk-form uk-margin-remove uk-display-inline-block">
                 <div class="uk-form-icon">


### PR DESCRIPTION
Same breadcrumbs markup as on other pages (ie. [Accounts page](https://github.com/aheinze/cockpit/blob/0.13.0/modules/core/Auth/views/accounts/index.php#L5)).

I wasn't sure about this one, as some other pages ([General](https://github.com/aheinze/cockpit/blob/0.13.0/modules/core/Cockpit/views/settings/general.php#L8), Addons) use h1