### PR TITLE
Updated PHPMailer to v5.2.10

### DIFF
--- a/vendor/PHPMailer/class.pop3.php
+++ b/vendor/PHPMailer/class.pop3.php
@@ -34,7 +34,7 @@ class POP3
      * @type string
      * @access public
      */
-    public $Version = '5.2.9';
+    public $Version = '5.2.10';
 
     /**
      * Default POP3 port number.
@@ -130,8 +130,8 @@ class POP3
     /**
      * Simple static wrapper for all-in-one POP before SMTP
      * @param $host
-     * @param boolean $port
-     * @param boolean $tval
+     * @param integer|boolean $port The port number to connect to
+     * @param integer|boolean $timeout The timeout value
      * @param string $username
      * @param string $password
      * @param integer $debug_level
@@ -140,13 +140,13 @@ class POP3
     public static function popBeforeSmtp(
         $host,
         $port = false,
-        $tval = false,
+        $timeout = false,
         $username = '',
         $password = '',
         $debug_level = 0
     ) {
         $pop = new POP3;
-        return $pop->authorise($host, $port, $tval, $username, $password, $debug_level);
+        return $pop->authorise($host, $port, $timeout, $username, $password, $debug_level);
     }
 
     /**


### PR DESCRIPTION
See [Releases](https://github.com/PHPMailer/PHPMailer/releases) > [PHPMailer 5.2.10](https://github.com/PHPMailer/PHPMailer/releases/tag/v5.2.10)

There's a [patch that will help with SMTP on PHP 5.6+](https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting#php-56-certificate-verification-failure). I doesn't apply automatically to Cockpit - we'd need to pass some more mail options to the instance. 