### PR TITLE
Add Countable Interface to MongoLite Cursor

### DIFF
--- a/vendor/MongoLite/Cursor.php
+++ b/vendor/MongoLite/Cursor.php
@@ -5,7 +5,7 @@ namespace MongoLite;
 /**
  * Cursor object.
  */
-class Cursor implements \Iterator{
+class Cursor implements \Iterator, \Countable {
 
     /**
      * @var boolean|integer


### PR DESCRIPTION
This helps with checking whether collection result set is empty, by `count($collection)`.

_I use Twig for rendering results set and it's `empty` expression checks if given object implements Countable interface. If so, returns count($collection);_

Since the Cursor class has already a [count](https://github.com/aheinze/cockpit/blob/0.13.0/vendor/MongoLite/Cursor.php#L67) method, all that needs to be done is to implement [Countable](http://php.net/countable) Interface