### PR TITLE
Option for slugs to be unique

### DIFF
--- a/modules/core/Cockpit/i18n/en.php
+++ b/modules/core/Cockpit/i18n/en.php
@@ -171,7 +171,7 @@ return [
     'Entry saved!' => '',
     'Load more...' => '',
     'Unique' => '',
-    'There is already an entry in this collection with the same unique field \'%s\'.',
+    'There is already an entry in this collection with this slug for field \'%s\'.',
 
     // Mediamanager
     'Mediamanager' => '',

--- a/modules/core/Cockpit/i18n/en.php
+++ b/modules/core/Cockpit/i18n/en.php
@@ -170,6 +170,8 @@ return [
     'Entry removed' => '',
     'Entry saved!' => '',
     'Load more...' => '',
+    'Unique' => '',
+    'There is already an entry in this collection with the same unique field \'%s\'.',
 
     // Mediamanager
     'Mediamanager' => '',

--- a/modules/core/Collections/Controller/Api.php
+++ b/modules/core/Collections/Controller/Api.php
@@ -188,7 +188,7 @@ class Api extends \Cockpit\Controller {
                     $this->app->response->status = 409;
 
                     return sprintf(
-                        $this->app->helper('i18n')->get("There is already an entry in this collection with the same unique field '%s'."),
+                        $this->app->helper('i18n')->get("There is already an entry in this collection with this slug for field '%s'."),
                         $fieldName
                     );
                 }

--- a/modules/core/Collections/Controller/Api.php
+++ b/modules/core/Collections/Controller/Api.php
@@ -175,6 +175,25 @@ class Api extends \Cockpit\Controller {
 
             $col = "collection".$collection["_id"];
 
+            // Check for uniqueeness of fields set as unique
+            foreach ($collection['fields'] as $fieldDefinition) {
+                
+                $fieldName = $fieldDefinition['name'];
+
+                if (
+                    $fieldDefinition['unique'] && 
+                    isset($entry[$fieldName]) && 
+                    $this->app->db->findOne("collections/{$col}", [$fieldName => $entry[$fieldName]])
+                ) {
+                    $this->app->response->status = 409;
+
+                    return sprintf(
+                        $this->app->helper('i18n')->get("There is already an entry in this collection with the same unique field '%s'."),
+                        $fieldName
+                    );
+                }
+            }
+
             if (!isset($entry["_id"])){
                 $entry["created"] = $entry["modified"];
             } else {

--- a/modules/core/Collections/views/collection.php
+++ b/modules/core/Collections/views/collection.php
@@ -94,6 +94,13 @@
                                                         </div>
                                                     </div>
 
+                                                    <div class="uk-form-row" data-ng-if="field.slug">
+                                                        <label class="uk-form-label">@lang('Unique')</label>
+                                                        <div class="uk-form-controls">
+                                                            <input type="checkbox" data-ng-model="field.unique" />
+                                                        </div>
+                                                    </div>
+
                                                     @if(count($locales))
                                                     <div class="uk-form-row">
                                                         <label class="uk-form-label">@lang('Localize')</label>


### PR DESCRIPTION
I'm using entry slugs in routes.

After this pull request when field type is set to _slug_, shows up another option to set it to _unique_.

Then when user tries to save an entry with a slug that is already present in collection, API returns a message `There is already an entry in this collection with this slug for field '[slugname]'.` and entry is not saved.