### PR TITLE
Unique fields bugfix

### DIFF
--- a/modules/core/Collections/Controller/Api.php
+++ b/modules/core/Collections/Controller/Api.php
@@ -176,21 +176,28 @@ class Api extends \Cockpit\Controller {
             $col = "collection".$collection["_id"];
 
             // Check for uniqueeness of fields set as unique
-            foreach ($collection['fields'] as $fieldDefinition) {
-                
-                $fieldName = $fieldDefinition['name'];
+            foreach ($collection["fields"] as $fieldDefinition) {
 
-                if (
-                    $fieldDefinition['unique'] && 
-                    isset($entry[$fieldName]) && 
-                    $this->app->db->findOne("collections/{$col}", [$fieldName => $entry[$fieldName]])
-                ) {
-                    $this->app->response->status = 409;
+                $fieldName = $fieldDefinition["name"] . "_slug";
 
-                    return sprintf(
-                        $this->app->helper('i18n')->get("There is already an entry in this collection with this slug for field '%s'."),
-                        $fieldName
-                    );
+                if ($fieldDefinition["slug"] && $fieldDefinition["unique"] && isset($entry[$fieldName])) {
+
+                    $collision = $this->app->db->findOne("collections/{$col}", [$fieldName => $entry[$fieldName]]);
+
+                    if (!$collision) {
+                        continue;
+                    }
+
+                    // New and colliding or other entry
+                    if (!isset($entry["_id"]) || $entry["_id"] != $collision["_id"]) {
+
+                        $this->app->response->status = 409;
+
+                        return sprintf(
+                            $this->app->helper("i18n")->get("There is already an entry in this collection with this slug for field '%s'."),
+                            $fieldDefinition["label"]
+                        );
+                    }
                 }
             }
 

--- a/modules/core/Collections/Controller/Api.php
+++ b/modules/core/Collections/Controller/Api.php
@@ -178,11 +178,11 @@ class Api extends \Cockpit\Controller {
             // Check for uniqueeness of fields set as unique
             foreach ($collection["fields"] as $fieldDefinition) {
 
-                $fieldName = $fieldDefinition["name"] . "_slug";
+                $slugName = $fieldDefinition["name"] . "_slug";
 
-                if ($fieldDefinition["slug"] && $fieldDefinition["unique"] && isset($entry[$fieldName])) {
+                if (!empty($fieldDefinition["slug"]) && !empty($fieldDefinition["unique"]) && isset($entry[$slugName])) {
 
-                    $collision = $this->app->db->findOne("collections/{$col}", [$fieldName => $entry[$fieldName]]);
+                    $collision = $this->app->db->findOne("collections/{$col}", [$slugName => $entry[$slugName]]);
 
                     if (!$collision) {
                         continue;


### PR DESCRIPTION
I found few problems with my PR #338.

- code wasn't checking for uniqueness of field's slug (but of the field value itself).
- when looking for conflicts, code didn't ignore it's own object, so it was not possible to save entries keeping same slug.
- in error message I've changed the display _name_ to _label_, as this is what user sees in the edit form.
