### PR TITLE
Removing is_numeric checks in gte, gt, lte, lt comparisions

### DIFF
--- a/vendor/MongoLite/Database.php
+++ b/vendor/MongoLite/Database.php
@@ -256,32 +256,27 @@ class UtilArrayQuery {
             case '$eq' :
                 $r = $a == $b;
                 break;
+
             case '$not' :
                 $r = $a != $b;
                 break;
+
             case '$gte' :
-                if (is_numeric($a) && is_numeric($b)) {
-                    $r = $a >= $b;
-                }
+                $r = $a >= $b;
                 break;
 
             case '$gt' :
-                if (is_numeric($a) && is_numeric($b)) {
-                    $r = $a > $b;
-                }
+                $r = $a > $b;
                 break;
 
             case '$lte' :
-                if (is_numeric($a) && is_numeric($b)) {
-                    $r = $a <= $b;
-                }
+                $r = $a <= $b;
                 break;
 
             case '$lt' :
-                if (is_numeric($a) && is_numeric($b)) {
-                    $r = $a < $b;
-                }
+                $r = $a < $b;
                 break;
+
             case '$in' :
                 if (! is_array($b))
                     throw new \InvalidArgumentException('Invalid argument for $in option must be array');


### PR DESCRIPTION
Because in PHP you can compare anything, see PHP.net: [Comparision operators](http://php.net/manual/en/language.operators.comparison.php#language.operators.comparison.types).

This is helpful when comparing dates stored in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `(true) '2015-06-06' > '2015-01-01'`.

Also this is more in line with the `$eq` and `$not` operators which ATM don't check if compared values are numeric.

Reference: Issue #343