### PR TITLE
Display image filename while editing meta in gallery

### DIFF
--- a/modules/core/Galleries/assets/js/gallery.js
+++ b/modules/core/Galleries/assets/js/gallery.js
@@ -199,4 +199,12 @@
 
     });
 
+    App.module.filter('filename', function() {
+        return function(input) {
+            if (input) {
+                return input.split('/').pop();
+            }
+        };
+    })
+
 })(jQuery);

--- a/modules/core/Galleries/views/gallery.php
+++ b/modules/core/Galleries/views/gallery.php
@@ -223,7 +223,8 @@
     <div id="meta-dialog" class="uk-modal">
         <div class="uk-modal-dialog">
             <a class="uk-modal-close uk-close"></a>
-            <h3>@lang('Meta')</h3>
+            <h3>@lang('Meta') for <b>@@ metaimage.path | filename @@</b></h3>
+
 
             <div class="uk-form uk-margin">
                 <div class="uk-form-row" data-ng-repeat="field in gallery.fields">


### PR DESCRIPTION
Help user when editing gallery image caption, width, height or other meta by displaying the filename in modal header.

Result:
![screen shot 2015-12-25 at 19 01 41](https://cloud.githubusercontent.com/assets/387611/12004047/488e350e-ab3a-11e5-9f42-cf7b0da8be00.png)
