### PR TITLE
Fix `undefined` ngModel for tag directive in gallery view

### DIFF
--- a/modules/core/Galleries/assets/js/gallery.js
+++ b/modules/core/Galleries/assets/js/gallery.js
@@ -3,13 +3,13 @@
     App.module.controller("gallery", function($scope, $rootScope, $http, $timeout, Contentfields){
 
         var id         = $("[data-ng-controller='gallery']").data("id"),
-            dialog     = UIkit.modal("#meta-dialog"),
             site_base  = COCKPIT_SITE_BASE_URL.replace(/^\/+|\/+$/g, ""),
             media_base = COCKPIT_MEDIA_BASE_URL.replace(/^\/+|\/+$/g, ""),
             site2media = media_base.replace(site_base, "").replace(/^\/+|\/+$/g, "");
 
         $scope.groups        = [];
         $scope.metaimage     = {};
+        $scope.modalOpen     = false;
         $scope.contentfields = Contentfields.fields();
 
         if (id) {
@@ -123,7 +123,18 @@
 
         $scope.showMeta = function(index){
             $scope.metaimage = $scope.gallery.images[index];
-            dialog.show();
+            $scope.modalOpen = true;
+            $timeout(function() {
+                UIkit.modal("#meta-dialog").show();
+            });
+        };
+
+        $scope.hideMeta = function(){
+            $scope.modalOpen = false;
+            $timeout(function() {
+                $scope.$apply('modalOpen');
+            }, 300);
+            UIkit.modal("#meta-dialog").hide();
         };
 
         $scope.addfield = function(){
@@ -194,6 +205,16 @@
                 e.returnValue = false; // ie
             }
             $scope.save();
+            return false;
+        });
+
+        Mousetrap.bindGlobal(['escape'], function(e) {
+            if (e.preventDefault) {
+                e.preventDefault();
+            } else {
+                e.returnValue = false; // ie
+            }
+            $scope.hideMeta();
             return false;
         });
 

--- a/modules/core/Galleries/views/gallery.php
+++ b/modules/core/Galleries/views/gallery.php
@@ -220,9 +220,9 @@
     </form>
 
 
-    <div id="meta-dialog" class="uk-modal">
+    <div id="meta-dialog" class="uk-modal" ng-if="modalOpen">
         <div class="uk-modal-dialog">
-            <a class="uk-modal-close uk-close"></a>
+            <a class="uk-modal-close uk-close" ng-click="hideMeta()"></a>
             <h3>@lang('Meta') for <b>@@ metaimage.path | filename @@</b></h3>
 
 
@@ -235,7 +235,7 @@
                 </div>
             </div>
 
-            <button class="uk-button uk-modal-close">@lang('Close')</button>
+            <button class="uk-button uk-modal-close" ng-click="hideMeta()">@lang('Close')</button>
         </div>
     </div>
 


### PR DESCRIPTION
**Issue:** Loading image tag data into modal after click fails because modal and fields are compiled before any ngModel is assigned to the tag field directive.

Solution: Create scope using `ng-if` on modal and compile modal fields after `ng-if`evaluates as `true` and creates new scope. That also requires changing modal behaviour on open (modal DOM is created after the click) and on close (binding close buttons, esc key to scope method).

*Note: there's 300ms timeout to finish modal hide transition according to CSS.*

See the XHR preview of `data.images[0].data.technique`.

Before:
![Before](https://cloud.githubusercontent.com/assets/387611/12057792/030cc7de-af45-11e5-8ef0-83fb7036d894.png)

After:
![After](https://cloud.githubusercontent.com/assets/387611/12057794/057f5504-af45-11e5-8f91-e4554cecf277.png)