### PR TITLE
Fixed issue #322, root media path can now be saved

### DIFF
--- a/modules/core/Auth/assets/js/groups.js
+++ b/modules/core/Auth/assets/js/groups.js
@@ -7,11 +7,11 @@
         $scope.active        = "admin";
 
         Object.keys(ACL_DATA).forEach(function(group){
-            $scope.groupsettings[group] = ACL_GROUP_SETTINGS[group] || {};
+            $scope.groupsettings[group] = ACL_GROUP_SETTINGS[group] || {"media.path" : "/"};
         });
 
         if (!Object.keys($scope.groupsettings).length) {
-            $scope.groupsettings['admin'] = {};
+        $scope.groupsettings['admin'] = {"media.path" : "/"};
         }
 
         if (location.hash && $scope.acl[location.hash.replace("#", "")]) {

--- a/modules/core/Auth/assets/js/groups.js
+++ b/modules/core/Auth/assets/js/groups.js
@@ -11,7 +11,7 @@
         });
 
         if (!Object.keys($scope.groupsettings).length) {
-        $scope.groupsettings['admin'] = {"media.path" : "/"};
+            $scope.groupsettings['admin'] = {"media.path" : "/"};
         }
 
         if (location.hash && $scope.acl[location.hash.replace("#", "")]) {


### PR DESCRIPTION
I just specify the default root value instead of passing an empty object which blocked saving.
Please note that there is probably a better way, but still, it doesn't even add a line. :)