### PR TITLE
Build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /config/*
 /modules/addons/*/*
 /tests/*
+/node_modules
 
 !.gitignore
 !.gitkeep

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ make also sure that <code>$_SERVER['DOCUMENT_ROOT']</code> exists and is set cor
 4. You're ready to use Cockpit :-)
 
 
+### Build
+
+You need [nodejs](https://nodejs.org/) installed on your system.
+
+First run `npm install` to install development dependencies
+
+a) Run `npm run build` - For one-time build of styles and components
+b) Run `npm run watch` - For continuous build every time styles or components change
+
+
 ### Copyright and license
 
 Copyright 2015 [Agentejo](http://www.agentejo.com) under the MIT license.

--- a/package.json
+++ b/package.json
@@ -13,5 +13,11 @@
 
         "watch-style": "watch-run -i -p 'assets/app/css/**/*.less' npm run build-style",
         "watch-components": "watch-run -i -p 'modules/core/Cockpit/assets/components/*.tag' npm run build-components"
+    },
+
+    "devDependencies": {
+        "less": "^2.6.0",
+        "riot": "^2.3.16",
+        "watch-run": "^1.2.4"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name"            : "cockpit-next",
     "version"         : "0.1.1",
+    "license"         : "MIT",
 
     "scripts": {
 


### PR DESCRIPTION
Add nodejs modules to package.json, so it's possible to run build scripts without having them installed globally.

Also added information in README.md file:

### Build

You need [nodejs](https://nodejs.org/) installed on your system.

First run `npm install` to install development dependencies

a) Run `npm run build` - For one-time build of styles and components
b) Run `npm run watch` - For continuous build every time styles or components change

___

ps: What about adding frontend assets (riot and uikit) too?