### PR TITLE
Collection links improvements

### DIFF
--- a/modules/core/Collections/assets/js/collection.js
+++ b/modules/core/Collections/assets/js/collection.js
@@ -107,9 +107,9 @@
                     continue;
                 }
 
-                // Allow just required fields
+                // Allow just simple fields
                 return $scope.collections[i].fields.filter(function(field) {
-                    return (field.required && fieldTypesBlacklist.indexOf(field.type) == -1);
+                    return (fieldTypesBlacklist.indexOf(field.type) == -1);
                 });
             }
 

--- a/modules/core/Collections/assets/js/entries.js
+++ b/modules/core/Collections/assets/js/entries.js
@@ -109,8 +109,8 @@
                             // Find fields which are type of link-collection
                             $scope.collection.fields.forEach(function(field) {
 
-                                // Continue field is not type of link-collection, 'Field on entries list page' is not selected or is not a collection ID
-                                if (field.type !== 'link-collection' || !field.collectionField || typeof entry[field.name] != 'string') {
+                                // Continue field is not type of link-collection, 'Field on entries list page' is not selected or value is not selected.
+                                if (field.type !== 'link-collection' || !field.collectionField || !entry[field.name]) {
                                     return;
                                 }
 

--- a/modules/core/Collections/views/collection.php
+++ b/modules/core/Collections/views/collection.php
@@ -147,7 +147,7 @@
                                                     <div class="uk-form-row" data-ng-if="field.type=='link-collection'">
                                                         <label class="uk-form-label">@lang('Field on entries list page')</label>
                                                         <div class="uk-form-controls">
-                                                            <select ng-options="f.name as f.label for f in getCollectionFields(field.collection)" data-ng-model="field.collectionField" title="@lang('Show these fields in entries list')" data-uk-tooltip>
+                                                            <select ng-options="f.name as (f.label || '[' + f.name + ']') for f in getCollectionFields(field.collection)" data-ng-model="field.collectionField" title="@lang('Show these fields in entries list')" data-uk-tooltip>
                                                                 <option value="">@lang('Collection Id')</option>
                                                             </select>
                                                         </div>


### PR DESCRIPTION
- Show field name if label is not filled in. At the moment it shows an empty <option> element
- Allow picking field which are not marked as required.
  When their value is not set, it's just not shown. It was pointless restriction and didn't really work
- Fix multiple collection-links (partial revert of https://github.com/aheinze/cockpit/pull/398/commits/b55400cd57e296fa623b682fec51f5f6f862439b)

This is extension to #394