### PR TITLE
Display locations address on entries page

### DIFF
--- a/modules/core/Collections/views/entries.php
+++ b/modules/core/Collections/views/entries.php
@@ -208,6 +208,18 @@
 
             return App.callmodule('collections:find', [this.collection.name, options]).then(function(data){
 
+                data.result.forEach(function(entry) {
+
+                    // Process fields
+                    for (var key in entry) {
+
+                        if (key in this.fieldsidx && this.fieldsidx[key].type == 'location') {
+                            // Use address to display value
+                            entry[key] = entry[key].address;
+                        }
+                    }
+                }, this);
+
                 this.entries = this.entries.concat(data.result);
 
                 this.ready    = true;


### PR DESCRIPTION
Fixes #402 
Better solution would be to implement a `toString` method inside location field type (and all other field types) and apply it on fetched entry data, but that is something to discuss.

I've got same fix for master branch too but I'll see if there are any comments for this one.